### PR TITLE
Relabel and remove unneeded typeset

### DIFF
--- a/foil.tex
+++ b/foil.tex
@@ -58,9 +58,7 @@ method\cite{chang_method_1995}.
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{flushleft}
-
-The introduction of airfoil:
+Terminology used for defining the airfoil:
 \begin{enumerate}
     \item
     Chord ($c$)
@@ -81,77 +79,69 @@ The introduction of airfoil:
     \centering
     \includegraphics[width=0.5\textwidth]{airfoil_shape_image.eps}
     \caption{The parameters in wing profile.}
-    \label{fig:airfoil_shape_image}
+    \label{f:airfoil_shape_image}
 \end{figure}
 % figure downloaded from: https://www.researchgate.net/figure/AIRFOIL-SHAPE-PARAMETERS_fig4_267490031
 
-\bigbreak
-The wing profile is defined by four-digit ($XYZZ$):
+The wing profile is defined by four-digit ($\mathrm{XYZZ}$):
 \begin{enumerate}
     \item
     The 1st digit is the maximum camber as percentage of the chord.
-    \begin{equation}
-        m = c \times (X/100)
-    \end{equation}
+    \begin{equation*}
+        m = c \times (\mathrm{X}/100)
+    \end{equation*}
     \item
     The 2nd digit is the maximum camber location in tenths of the chord.
-    \begin{equation}
-        p = c \times (Y/10)
-    \end{equation}
+    \begin{equation*}
+        p = c \times (\mathrm{Y}/10)
+    \end{equation*}
     \item
     The last two digits are the maximum thickness as percent of the chord.
-    \begin{equation}
-        h = c \times (ZZ/100)
-    \end{equation}
+    \begin{equation*}
+        h = c \times (\mathrm{ZZ}/100)
+    \end{equation*}
 \end{enumerate}
 
-\bigbreak
-The thickness equation is
-\begin{equation}
-    y_h = 5h[0.2969\sqrt{x}-0.1260x-0.3516x^2+0.2843x^3-0.1015x^4]
-\end{equation}
+The formula to calculate the thickness is
+\begin{equation*}
+    y_h = 5h\left(0.2969\sqrt{x}-0.1260x-0.3516x^2+0.2843x^3-0.1015x^4\right)
+\end{equation*}
 where $x$ is the position along the chord (from $0$ to $1$), $y_h$ is the
 half thickness at a given value of $x$, and $h$ is the maximum thickness.
 
-\bigbreak
 The camber line equation is
-\begin{equation}
+\begin{equation*}
     y_c =
     \begin{cases}
     \frac{m}{p^2} (2px - x^2); & 0 \leq x \leq p \\
     \frac{m}{(1-p)^2} (1 - 2p + 2px - x^2);  &  p \leq x \leq 1
     \end{cases}
-\end{equation}
+\end{equation*}
 where $y_c$ is the camber line point at a given value of $x$, $m$ is the
 maximum camber, and $p$ is the location of maximum camber.
 
-\bigbreak
 The upper surface equation is
-\begin{equation}
-    x_u = x - y_h \sin\theta
-    \label{eq:naca:up_x}
-\end{equation}
-\begin{equation}
-    y_u = y_c + y_h \cos\theta
-    \label{eq:naca:up_y}
-\end{equation}
+\begin{align}
+    x_u &= x - y_h \sin\theta
+    \label{e:naca:up_x}
+    \\
+    y_u &= y_c + y_h \cos\theta
+    \label{e:naca:up_y}
+\end{align}
 and the lower surface equation is
-\begin{equation}
-    x_l = x + y_h \sin\theta
-\end{equation}
-\begin{equation}
-    y_l = y_c - y_h \cos\theta
-\end{equation}
+\begin{align*}
+    x_l &= x + y_h \sin\theta
+    \\
+    y_l &= y_c - y_h \cos\theta
+\end{align*}
 where
-\begin{equation}
+\begin{equation*}
     \theta =
     \begin{cases}
     \frac{2m}{p^2} (p - x); & 0 \leq x \leq p \\
     \frac{2m}{(1-p)^2} (p - x);  &  p \leq x \leq 1
     \end{cases}
-\end{equation}
-
-\end{flushleft}
+\end{equation*}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -161,35 +151,31 @@ where
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{flushleft}
-
 The cubic Bezier curve is defined by 4 controll points $P_0(X_0, Y_0)$,
 $P_1(X_1, Y_1)$, $P_2(X_2, Y_2)$, and $P_3(X_3, Y_3)$.
 \begin{figure}[h]
     \centering
     \includegraphics[width=0.3\textwidth]{cubic_bezier_curve.eps}
     \caption{The cubic Bezier curve.}
-    \label{fig:cubic_bezier_curve}
+    \label{f:cubic_bezier_curve}
 \end{figure}
 % figure downloaded from: https://btnseniorproject17.wordpress.com/2017/05/01/more-unity-part-2-path-following-and-bezier-curves/
 
-\bigbreak
 The function $B(t)$ is
 \begin{equation}
     B(t) = (1-t)^3 P_0 + 3(1-t)^2 t P_1 + 3(1-t) t^2 P_2 + t^3 P_3
-    \label{eq:cbc:der0}
+    \label{e:cbc:der0}
 \end{equation}
-where $0 \leq t \leq 1$. \\
-The derivative of $B(t)$ is
+where $0 \leq t \leq 1$.  The first-order derivative of $B(t)$ is
 \begin{equation}
-    B'(t) = 3[(1-t)^2 (P_1 - P_0) + 2(1-t)t(P_2 - P_1) + t^2(P_3 - P_2)]
+    B'(t) = 3\left[
+      (1-t)^2 (P_1 - P_0) + 2(1-t)t(P_2 - P_1) + t^2(P_3 - P_2)
+    \right]
 \end{equation}
-The second derivative of $B(t)$ is
+The second-order derivative of $B(t)$ is
 \begin{equation}
-    B''(t) = 6[(1-t)(P_2 - 2P_1 + P_0) + t(P_3 - 2P_2 + P_1)]
+    B''(t) = 6\left[(1-t)(P_2 - 2P_1 + P_0) + t(P_3 - 2P_2 + P_1)\right]
 \end{equation}
-
-\end{flushleft}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -199,35 +185,30 @@ The second derivative of $B(t)$ is
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{flushleft}
-
 Linear least squares (LLS) is a set of formulations for solving statistical
 problems involved in linear regression, including variants for ordinary,
 weighted, and generalized residuals.
 
-\bigbreak
 Consider the linear equation
 \begin{equation}
     Ax = b
-    \label{eq:lls:leq}
+    \label{e:lls:leq}
 \end{equation}
 where $A \in \mathbb{R}^{m \times n}$ and $b \in \mathbb{R}^m$. when $m>n$,
 $x \in \mathbb{R}^n$ is the solution of
-\begin{equation}
+\begin{equation*}
     \underset{x \in \mathbb{R}^n}{\text{minimize}} ||A x - b||^2
-\end{equation}
+\end{equation*}
 $x$ can be computed by
-\begin{equation}
+\begin{equation*}
     A^\top A x^* = A^\top b
-\end{equation}
-\begin{equation}
+\end{equation*}
+\begin{equation*}
     x^* = (A^\top A)^{-1} A^\top b
-    \label{eq:lls:sol}
-\end{equation}
+    \label{e:lls:sol}
+\end{equation*}
 where $A^\top$ denotes the transpose of $A$ and $Ax^*$ is the projection of
 $b$ in columnn space of $A$.
-
-\end{flushleft}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -236,33 +217,31 @@ $b$ in columnn space of $A$.
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{flushleft}
-
-By adapting a symmetry four-digit NACA airfoil ($00ZZ$), the maximum camber
-($m$) and maximum camber location ($p$) are equal to $0$. Then,
-Eq.(\ref{eq:naca:up_x}) and Eq.(\ref{eq:naca:up_y}) of airfoil upper
-surface can be simplified as
+By adapting a symmetry four-digit NACA airfoil ($\mathrm{00ZZ}$), the maximum
+camber ($m$) and maximum camber location ($p$) are equal to $0$. Then,
+Eq.~(\ref{e:naca:up_x}) and Eq.~(\ref{e:naca:up_y}) of airfoil upper surface
+can be simplified as
 \begin{equation}
     x_u = x
-    \label{eq:naca:up_x_sym}
+    \label{e:naca:up_x_sym}
 \end{equation}
 \begin{equation}
     y_u = 5h[0.2969\sqrt{x}-0.1260x-0.3516x^2+0.2843x^3-0.1015x^4]
-    \label{eq:naca:up_y_sym}
+    \label{e:naca:up_y_sym}
 \end{equation}
 Here, we fix the first and the last controll points at leading edge and
-trailing edge. Eq.(\ref{eq:cbc:der0}) becomes
-\begin{equation}
+trailing edge. Eq.~(\ref{e:cbc:der0}) becomes
+\begin{equation*}
     \begin{bmatrix} x_u \\ y_u \end{bmatrix}
         = 3(1-t)^2 t \begin{bmatrix} X_1 \\ Y_1 \end{bmatrix}
         + 3(1-t) t^2 \begin{bmatrix} X_2 \\ Y_2 \end{bmatrix}
         + t^3 \begin{bmatrix} c \\ 0 \end{bmatrix}
-\end{equation}
-We adapt $N$ data points in airfoil upper surface to get the fitting curve.
-By assuming the distribution of $x$ inEq.(\ref{eq:naca:up_x_sym}) and
-Eq.(\ref{eq:naca:up_x_sym}) is the same as $t$ in Eq.(\ref{eq:cbc:der0}).
-The linear least square equation can be written as
-\begin{equation}
+\end{equation*}
+We adapt $N$ data points in airfoil upper surface to get the fitting curve.  By
+assuming the distribution of $x$ in Eq.~(\ref{e:naca:up_x_sym}) and
+Eq.~(\ref{e:naca:up_x_sym}) is the same as $t$ in Eq.~(\ref{e:cbc:der0}).  The
+linear least square equation can be written as
+\begin{equation*}
     \begin{bmatrix}
         3(1 - x_0)^2 x_0 & 3(1 - x_0) x_0^2 \\
         3(1 - x_1)^2 x_1 & 3(1 - x_1) x_1^2 \\
@@ -270,7 +249,7 @@ The linear least square equation can be written as
         3(1 - x_{N-1})^2 x_{N-1} & 3(1 - x_{N-1}) x_{N-1}^2 \\
     \end{bmatrix}
     \begin{bmatrix}
-        X_1 & Y_1 \\ 
+        X_1 & Y_1 \\
         X_2 & Y_2
     \end{bmatrix}
     =
@@ -278,13 +257,11 @@ The linear least square equation can be written as
         x_u(x_0) - x_0^3 c & y_u(x_0) \\
         x_u(x_1) - x_1^3 c & y_u(x_1) \\
         \vdots \\
-        x_u(x_{N-1}) - x_{N-1}^3 c & y_u(x_{N-1}) 
+        x_u(x_{N-1}) - x_{N-1}^3 c & y_u(x_{N-1})
     \end{bmatrix}
-\end{equation}
+\end{equation*}
 The controll points $P_1(X_1, Y_1)$ and $P_2(X_2, Y_2)$ can be solved by
-Eq.(\ref{eq:lls:sol}). 
-
-\end{flushleft}
+Eq.~(\ref{e:lls:sol}).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%


### PR DESCRIPTION
Summary of the change:

- Remove unneeded typesetting commands like `flushleft` and `\bigbreak`.
- Remove the labels of the equations that are not referenced in the note by replacing `equation` with `equation*`.
- Use `align` to replace `equation` when multi-line equations make sense.
- Replace the label `fig:*` with `f:*`.  A single character is enough to distinguish the type of the label.
- Replace the label `eq:*` with `e:*`.