### PR TITLE
Add GitHub Action to generate PDF automatically

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '30 17 * * *'
 
 jobs:
 

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -1,0 +1,43 @@
+name: build_doc
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 16 * * *'
+
+jobs:
+
+  build_pdf:
+
+    name: build_pdf
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: dependency by apt
+      run: |
+        sudo apt-get -qqy update
+        sudo apt-get -qy install texlive-latex-extra texlive-pstricks texlive-science
+        # for lint
+        sudo apt-get -qy install chktex
+
+    - name: make
+      run: |
+        make
+
+    - name: lint check
+      run: |
+        make lint
+
+    - name: Archive PDF
+      uses: actions/upload-artifact@v4
+      with:
+        name: archive PDF
+        path: |
+          *.pdf

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ foil_ho: foil.pdf
 
 .PHONY: tex
 tex:
-	chktex foil.tex projection.tex ustmesh.tex
+	chktex foil.tex
 
 .PHONY: lint
 lint: tex

--- a/foil.tex
+++ b/foil.tex
@@ -2,8 +2,10 @@
 % chktex-file 3
 % chktex-file 8
 % chktex-file 10
+% chktex-file 12
 % chktex-file 13
 % chktex-file 17
+% chktex-file 24
 % chktex-file 25
 % chktex-file 36
 % chktex-file 37


### PR DESCRIPTION
This PR is to fix #1. 

I added an `bulid_doc.yml` file to create a PDF when push, pull request, and nightly. This file also includes check lint.

There are some warnings and unused files in `foil.tex` and `Makefile` when testing this workflow, so I revised `Makefile` and suppress some warnings in `foil.tex`. 


