### PR TITLE
Revise typo

### DIFF
--- a/foil.tex
+++ b/foil.tex
@@ -2,7 +2,6 @@
 % chktex-file 3
 % chktex-file 8
 % chktex-file 10
-% chktex-file 12
 % chktex-file 13
 % chktex-file 17
 % chktex-file 24
@@ -196,7 +195,7 @@ Consider the linear equation
     Ax = b
     \label{e:lls:leq}
 \end{equation}
-where $A \in \mathbb{R}^{m \times n}$ and $b \in \mathbb{R}^m$. when $m>n$,
+where $A \in \mathbb{R}^{m \times n}$ and $b \in \mathbb{R}^m$. When $m>n$,
 $x \in \mathbb{R}^n$ is the solution of
 \begin{equation*}
     \underset{x \in \mathbb{R}^n}{\text{minimize}} ||A x - b||^2


### PR DESCRIPTION
The PR solves warning in issue #7 

1. Revise typo for warning 12.
2. Keep `% chktex-file 25` to avoid warning 24.  
To solve the problem, the code 
https://github.com/yungyuc/bezierfoil/blob/0655bbb76d0175c6d3cc52724636cb158ebe3942/foil.tex#L83-L84
https://github.com/yungyuc/bezierfoil/blob/0655bbb76d0175c6d3cc52724636cb158ebe3942/foil.tex#L161-L162
will become
`    \caption{The parameters in wing profile.}\label{f:airfoil_shape_image}` 
`    \caption{The cubic Bezier curve.}\label{f:cubic_bezier_curve}`
But, I don't think it is better.